### PR TITLE
Refine division operation in Albatross.Expression

### DIFF
--- a/src/Albatross.Expression.Test/Operations/GeneralOperationTests.cs
+++ b/src/Albatross.Expression.Test/Operations/GeneralOperationTests.cs
@@ -61,8 +61,13 @@ namespace Albatross.Expression.Test
         //arithmatic
         [TestCase("2*3", ExpectedResult = 6)]
         [TestCase("2*null", ExpectedResult = null)]
-
+        
         [TestCase("4/2", ExpectedResult = 2)]
+        [TestCase("13/3", ExpectedResult = 4.333)]
+        [TestCase("5/2", ExpectedResult = 2.500)]
+        [TestCase("15/2", ExpectedResult = 7.500)]
+        [TestCase("19/4", ExpectedResult = 4.750)]
+        [TestCase("22/7", ExpectedResult = 3.143)]
         [TestCase("4/0", ExpectedResult = double.PositiveInfinity)]
 
         [TestCase("-12", ExpectedResult = -12)]

--- a/src/Albatross.Expression/Operations/Divide.cs
+++ b/src/Albatross.Expression/Operations/Divide.cs
@@ -35,7 +35,7 @@ namespace Albatross.Expression.Operations
 
             if (a is double && b is double)
             {
-                return (double)a / (double)b;
+                return Math.Round((double)a / (double)b, 2);
             }
             else
             {

--- a/src/Albatross.Expression/Operations/Divide.cs
+++ b/src/Albatross.Expression/Operations/Divide.cs
@@ -35,7 +35,8 @@ namespace Albatross.Expression.Operations
 
             if (a is double && b is double)
             {
-                return Math.Round((double)a / (double)b, 2);
+                var result = Math.Round((double)a / (double)b, 3);
+                return result;
             }
             else
             {


### PR DESCRIPTION
This change adds rounding to the division operation in the Albatross.Expression library. Now, results of the division operation between double values will be rounded to two decimal places.